### PR TITLE
Endrer litt på rekkefølge ved shutdown og lukker også db-pool

### DIFF
--- a/app/main/innsending/postgres/PostgresDatasource.kt
+++ b/app/main/innsending/postgres/PostgresDatasource.kt
@@ -17,7 +17,7 @@ internal object Hikari {
         config: PostgresConfig,
         locations: Array<String> = arrayOf("classpath:db/migration", "classpath:db/gcp"),
         meterRegistry: MeterRegistry? = null
-    ): DataSource {
+    ): HikariDataSource {
         val hikariConfig = HikariConfig().apply {
             jdbcUrl = config.url
             username = config.username
@@ -37,7 +37,7 @@ internal object Hikari {
     fun createAndMigrate(
         config: HikariConfig,
         locations: Array<String>
-    ): DataSource {
+    ): HikariDataSource {
         val dataSource = HikariDataSource(config)
 
         val flyway = Flyway

--- a/app/test/innsending/postgres/PostgresTestBase.kt
+++ b/app/test/innsending/postgres/PostgresTestBase.kt
@@ -1,12 +1,13 @@
 package innsending.postgres
 
+import com.zaxxer.hikari.HikariDataSource
 import innsending.InitTestDatabase
 import org.junit.jupiter.api.BeforeEach
 import java.util.UUID
 import javax.sql.DataSource
 
 abstract class PostgresTestBase {
-    protected val dataSource: DataSource = Hikari.createAndMigrate(
+    protected val dataSource: HikariDataSource = Hikari.createAndMigrate(
         InitTestDatabase.hikariConfig,
         arrayOf("classpath:db/migration")
     )


### PR DESCRIPTION
- Lukker database-pool
- Shutdown på motor så tidlig som mulig når applikasjonen er på vei ned for å unngå at nye tasks settes i gang
- Fjerner unødvendig unsubscribes som uansett ikke gjør noe mtp at de ikke sender inn riktig referanse