### PR TITLE
chore: add systemkatalog.nav.no/system label to nais manifest

### DIFF
--- a/.nais/application-dev.yml
+++ b/.nais/application-dev.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     team: aap
     sub: innsending
+    systemkatalog.nav.no/system: TE-496
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "50M"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "90"

--- a/.nais/application-dev.yml
+++ b/.nais/application-dev.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: aap
     sub: innsending
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "50M"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "90"

--- a/.nais/application-prod.yml
+++ b/.nais/application-prod.yml
@@ -6,6 +6,7 @@ metadata:
   labels:
     team: aap
     sub: innsending
+    systemkatalog.nav.no/system: TE-496
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "50M"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "90"

--- a/.nais/application-prod.yml
+++ b/.nais/application-prod.yml
@@ -6,7 +6,7 @@ metadata:
   labels:
     team: aap
     sub: innsending
-    systemkatalog.nav.no/system: TE-496
+    systemkatalog.nav.no/system: SK-268
   annotations:
     nginx.ingress.kubernetes.io/proxy-body-size: "50M"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "90"


### PR DESCRIPTION
Adds the `systemkatalog.nav.no/system: TE-496` label to the nais Application manifest so this app is registered in systemkatalog.nav.no.